### PR TITLE
Use labs instead of abs

### DIFF
--- a/CXCountDownLabel/CXCountDownLabel.m
+++ b/CXCountDownLabel/CXCountDownLabel.m
@@ -128,7 +128,7 @@
 - (void)countDown
 {
     _ascending = (_endNumber > _currentNumber);
-    NSInteger interval = abs(_currentNumber - _endNumber);
+    NSInteger interval = labs(_currentNumber - _endNumber);
     NSInteger c = 0;
     if (_countInterval > interval) {
         c = interval;


### PR DESCRIPTION
This fixes the warning `Implicit conversion loses integer precision: long to int`
